### PR TITLE
fix: use relative paths for resources

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,23 +2,23 @@
 Sideview Boxing — LIB layout (no bundler)
 
 1) Copy Three.js files to these paths (exactly):
-   /boxing/lib/three/build/three.module.js
-   /boxing/lib/three/examples/jsm/loaders/FBXLoader.js
-   /boxing/lib/three/examples/jsm/controls/OrbitControls.js
+   lib/three/build/three.module.js
+   lib/three/examples/jsm/loaders/FBXLoader.js
+   lib/three/examples/jsm/controls/OrbitControls.js
 
    (Optional, if some old import requests /examples/js/*, shims are provided at:
-   /boxing/lib/three/examples/js/loaders/FBXLoader.js
-   /boxing/lib/three/examples/js/controls/OrbitControls.js )
+   lib/three/examples/js/loaders/FBXLoader.js
+   lib/three/examples/js/controls/OrbitControls.js )
 
 2) (Optional) Physics — put Rapier here:
-   /boxing/lib/rapier/rapier.es.js
-   /boxing/lib/rapier/rapier_wasm3d_bg.wasm
+   lib/rapier/rapier.es.js
+   lib/rapier/rapier_wasm3d_bg.wasm
 
 3) Put your character FBX here:
-   /boxing/assets/character.fbx
+   assets/character.fbx
 
-4) Serve the /boxing folder via http(s)://yourhost/boxing/
-   Open: http://localhost/boxing/#/match
+4) Serve the project root via http(s)://yourhost/
+   Open: http://localhost/#/match
 
 This build uses /js/views/* (not /js/pages/*) and a LIB folder (no vendor).
 Created: 2025-09-14T01:52:23.195573Z

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Sideview Boxing</title>
-    <link rel="stylesheet" href="/boxing/css/styles.css"/>
+    <link rel="stylesheet" href="./css/styles.css"/>
     <script type="importmap">
     {
       "imports": {
-        "three": "/boxing/lib/three/build/three.module.js"
+        "three": "./lib/three/build/three.module.js"
       }
     }
     </script>
@@ -26,6 +26,6 @@
       <div id="app"></div>
       <div style="margin-top:20px">Three.js • FBX (Mixamo) • Local templates • Singleplayer only (for now)</div>
     </div>
-    <script type="module" src="/boxing/js/main.js"></script>
+    <script type="module" src="./js/main.js"></script>
   </body>
 </html>

--- a/js/core/three-setup.js
+++ b/js/core/three-setup.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { OrbitControls } from '/boxing/lib/three/examples/jsm/controls/OrbitControls.js';
+import { OrbitControls } from '../../lib/three/examples/jsm/controls/OrbitControls.js';
 
 export function makeThree(canvasParent){
   const scene = new THREE.Scene();

--- a/js/main.js
+++ b/js/main.js
@@ -2,9 +2,9 @@
 const app = document.getElementById('app');
 
 const routes = {
-  '#/menu': () => import('/boxing/js/views/menu.js'),
-  '#/editor': () => import('/boxing/js/views/editor.js'),
-  '#/match': () => import('/boxing/js/views/match.js'),
+  '#/menu': () => import('./views/menu.js'),
+  '#/editor': () => import('./views/editor.js'),
+  '#/match': () => import('./views/match.js'),
 };
 
 function showError(msg){

--- a/js/views/match.js
+++ b/js/views/match.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { FBXLoader } from '/boxing/lib/three/examples/jsm/loaders/FBXLoader.js';
+import { FBXLoader } from '../../lib/three/examples/jsm/loaders/FBXLoader.js';
 import { makeThree } from '../core/three-setup.js';
 
 export function mount(root){
@@ -19,7 +19,7 @@ export function mount(root){
   app.scene.add(cube);
 
   // Try to load your local character if present.
-  const tryPath = '/boxing/assets/character.fbx';
+  const tryPath = '../../assets/character.fbx';
   const loader = new FBXLoader();
   loader.load(tryPath, (g)=>{
     g.traverse(o=>{ o.castShadow = true; });
@@ -27,6 +27,6 @@ export function mount(root){
     app.scene.add(g);
     console.log('[FBX] loaded', g);
   }, undefined, (e)=>{
-    console.warn('[FBX] Could not load /boxing/assets/character.fbx (this is ok for now).');
+    console.warn('[FBX] Could not load ' + tryPath + ' (this is ok for now).');
   });
 }

--- a/lib/three/PUT_THREE_HERE.txt
+++ b/lib/three/PUT_THREE_HERE.txt
@@ -1,9 +1,9 @@
 Place Three.js ES module files here:
 
 Required (exact paths):
-  /boxing/lib/three/build/three.module.js
-  /boxing/lib/three/examples/jsm/loaders/FBXLoader.js
-  /boxing/lib/three/examples/jsm/controls/OrbitControls.js
+  lib/three/build/three.module.js
+  lib/three/examples/jsm/loaders/FBXLoader.js
+  lib/three/examples/jsm/controls/OrbitControls.js
 
 Tip: If you have node installed:
   npm i three@0.161


### PR DESCRIPTION
## Summary
- use relative paths for all scripts, styles, and imports
- update match view to reference local assets with relative paths
- refresh README and library instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c727050650833080efbbbe7634f43f