### PR TITLE
fix: dynamically resolve three.js path

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,24 +1,26 @@
 
 Sideview Boxing — LIB layout (no bundler)
 
-1) Copy Three.js files to these paths (exactly):
-   /boxing/lib/three/build/three.module.js
-   /boxing/lib/three/examples/jsm/loaders/FBXLoader.js
-   /boxing/lib/three/examples/jsm/controls/OrbitControls.js
+1) Copy Three.js files to these paths. The app looks for `lib/three` first
+   and falls back to `vendor/three` for older layouts:
+   lib/three/build/three.module.js
+   lib/three/examples/jsm/loaders/FBXLoader.js
+   lib/three/examples/jsm/controls/OrbitControls.js
 
    (Optional, if some old import requests /examples/js/*, shims are provided at:
-   /boxing/lib/three/examples/js/loaders/FBXLoader.js
-   /boxing/lib/three/examples/js/controls/OrbitControls.js )
+   lib/three/examples/js/loaders/FBXLoader.js
+   lib/three/examples/js/controls/OrbitControls.js )
 
 2) (Optional) Physics — put Rapier here:
-   /boxing/lib/rapier/rapier.es.js
-   /boxing/lib/rapier/rapier_wasm3d_bg.wasm
+   lib/rapier/rapier.es.js
+   lib/rapier/rapier_wasm3d_bg.wasm
 
 3) Put your character FBX here:
-   /boxing/assets/character.fbx
+   assets/character.fbx
 
-4) Serve the /boxing folder via http(s)://yourhost/boxing/
-   Open: http://localhost/boxing/#/match
+4) Serve the project root via http(s)://yourhost/
+   Open: http://localhost/#/match
 
-This build uses /js/views/* (not /js/pages/*) and a LIB folder (no vendor).
+This build uses /js/views/* (not /js/pages/*) and prefers a LIB folder but
+will fall back to a vendor folder if present.
 Created: 2025-09-14T01:52:23.195573Z

--- a/index.html
+++ b/index.html
@@ -4,14 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Sideview Boxing</title>
-    <link rel="stylesheet" href="/boxing/css/styles.css"/>
-    <script type="importmap">
-    {
-      "imports": {
-        "three": "/boxing/lib/three/build/three.module.js"
-      }
-    }
-    </script>
+    <link rel="stylesheet" href="./css/styles.css"/>
     <style>
       body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#0b1017;color:#dbe0ea}
       a{color:#8ab4ff;text-decoration:none;margin-right:12px}
@@ -26,6 +19,6 @@
       <div id="app"></div>
       <div style="margin-top:20px">Three.js • FBX (Mixamo) • Local templates • Singleplayer only (for now)</div>
     </div>
-    <script type="module" src="/boxing/js/main.js"></script>
+    <script type="module" src="./js/main.js"></script>
   </body>
 </html>

--- a/js/core/three-setup.js
+++ b/js/core/three-setup.js
@@ -1,7 +1,23 @@
-import * as THREE from 'three';
-import { OrbitControls } from '/boxing/lib/three/examples/jsm/controls/OrbitControls.js';
+async function loadThree(){
+  try{
+    return await import('../../lib/three/build/three.module.js');
+  }catch{
+    return await import('../../vendor/three/build/three.module.js');
+  }
+}
 
-export function makeThree(canvasParent){
+async function loadOrbit(){
+  try{
+    return (await import('../../lib/three/examples/jsm/controls/OrbitControls.js')).OrbitControls;
+  }catch{
+    return (await import('../../vendor/three/examples/jsm/controls/OrbitControls.js')).OrbitControls;
+  }
+}
+
+export async function makeThree(canvasParent){
+  const THREE = await loadThree();
+  const OrbitControls = await loadOrbit();
+
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x0b1017);
   const camera = new THREE.PerspectiveCamera(50, 16/9, 0.1, 100);

--- a/js/main.js
+++ b/js/main.js
@@ -2,9 +2,9 @@
 const app = document.getElementById('app');
 
 const routes = {
-  '#/menu': () => import('/boxing/js/views/menu.js'),
-  '#/editor': () => import('/boxing/js/views/editor.js'),
-  '#/match': () => import('/boxing/js/views/match.js'),
+  '#/menu': () => import('./views/menu.js'),
+  '#/editor': () => import('./views/editor.js'),
+  '#/match': () => import('./views/match.js'),
 };
 
 function showError(msg){
@@ -18,7 +18,7 @@ async function render(){
     const mod = await loader();
     const mount = mod.mount || mod.default;
     app.innerHTML = '';
-    mount(app);
+    await mount(app);
   }catch(err){
     console.error(err);
     showError(err?.message || String(err));

--- a/js/views/match.js
+++ b/js/views/match.js
@@ -1,14 +1,21 @@
-import * as THREE from 'three';
-import { FBXLoader } from '/boxing/lib/three/examples/jsm/loaders/FBXLoader.js';
 import { makeThree } from '../core/three-setup.js';
 
-export function mount(root){
+async function loadFBX(){
+  try{
+    return (await import('../../lib/three/examples/jsm/loaders/FBXLoader.js')).FBXLoader;
+  }catch{
+    return (await import('../../vendor/three/examples/jsm/loaders/FBXLoader.js')).FBXLoader;
+  }
+}
+
+export async function mount(root){
   const panel = document.createElement('div');
   const canvas = document.createElement('div');
   panel.appendChild(canvas);
   root.appendChild(panel);
 
-  const app = makeThree(canvas);
+  const app = await makeThree(canvas);
+  const FBXLoader = await loadFBX();
 
   // Simple sanity cube so you see something even if FBX missing.
   const cube = new app.THREE.Mesh(
@@ -19,7 +26,7 @@ export function mount(root){
   app.scene.add(cube);
 
   // Try to load your local character if present.
-  const tryPath = '/boxing/assets/character.fbx';
+  const tryPath = '../../assets/character.fbx';
   const loader = new FBXLoader();
   loader.load(tryPath, (g)=>{
     g.traverse(o=>{ o.castShadow = true; });
@@ -27,6 +34,6 @@ export function mount(root){
     app.scene.add(g);
     console.log('[FBX] loaded', g);
   }, undefined, (e)=>{
-    console.warn('[FBX] Could not load /boxing/assets/character.fbx (this is ok for now).');
+    console.warn('[FBX] Could not load ' + tryPath + ' (this is ok for now).');
   });
 }

--- a/lib/three/PUT_THREE_HERE.txt
+++ b/lib/three/PUT_THREE_HERE.txt
@@ -1,9 +1,9 @@
 Place Three.js ES module files here:
 
 Required (exact paths):
-  /boxing/lib/three/build/three.module.js
-  /boxing/lib/three/examples/jsm/loaders/FBXLoader.js
-  /boxing/lib/three/examples/jsm/controls/OrbitControls.js
+  lib/three/build/three.module.js
+  lib/three/examples/jsm/loaders/FBXLoader.js
+  lib/three/examples/jsm/controls/OrbitControls.js
 
 Tip: If you have node installed:
   npm i three@0.161


### PR DESCRIPTION
## Summary
- remove import map and detect Three.js library at runtime
- make loader utilities handle both `lib/` and legacy `vendor/` locations
- clarify README about library lookup order

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c727050650833080efbbbe7634f43f